### PR TITLE
Refactor code and pipeline for best practices

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
+# Copyright The Linux Foundation and each contributor.
+# SPDX-License-Identifier: MIT
+
 .git
 .env
 /bin/*

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,10 +14,10 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version: '1.22.x'
-      - uses: actions/checkout@v4
       - uses: ko-build/setup-ko@v0.6
       - run: |
           ko build --bare --platform linux/amd64,linux/arm64 -t latest -t ${{ github.sha }} --sbom spdx .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright The Linux Foundation and its contributors.
 # SPDX-License-Identifier: MIT
 
-FROM --platform=$BUILDPLATFORM cgr.dev/chainguard/go AS builder
+FROM --platform=$BUILDPLATFORM cgr.dev/chainguard/go:latest AS builder
 
 # Set necessary environment variables needed for our image. Allow building to
 # other architectures via cross-compliation build-arg.

--- a/check-headers.sh
+++ b/check-headers.sh
@@ -7,31 +7,29 @@
 # Exits with a 0 if all source files have license headers
 # Exits with a 1 if one or more source files are missing a license header
 
-# These are the file patterns we should exclude - these are typically transient files not checked into source control
-exclude_pattern='node_modules|.venv|.pytest_cache|.idea'
+# Exclude code coming from a third-party. Typically these won't be checked into
+# source control, but occassionally "vendored" code is committed.
+exclude_pattern='^(.*/)?(node_modules|vendor)/'
+
+# Include build definitions.
+filetypes=(Makefile Dockerfile .gitignore .dockerignore)
+# Include Golang files.
+filetypes+=("*.go" go.mod)
+# Include Python files.
+filetypes+=("*.py")
+# Include HTML, CSS, JS, TS, SCSS.
+filetypes+=("*.html" "*.htm" "*.css" "*.ts" "*.js" "*.scss")
+# Include shell scripts.
+filetypes+=("*.sh" "*.bash" "*.ksh" "*.csh" "*.tcsh" "*.fsh")
+# Include text.
+filetypes+=("*.txt")
+# Include YAML and TOML files.
+filetypes+=("*.yaml" "*.yml" "*.toml")
+# Include SQL scripts and definitions.
+filetypes+=("*.sql")
 
 files=()
-echo "Scanning source code..."
-# Adjust this filters based on the source files you are interested in checking
-# Loads all the filenames into an array
-# We need optimize this, possibly use: -name '*.go' -o -name '*.txt' - not working as expected on mac
-echo 'Searching *.go|go.mod files...'
-files+=($(find . -type f \( -name '*.go' -o -name 'go.mod' \) -print | egrep -v ${exclude_pattern}))
-echo "Searching python files..."
-files+=($(find . -type f -name '*.py' -print | egrep -v ${exclude_pattern}))
-echo "Searching html|css|ts|js files..."
-files+=($(find . -type f \( -name '*.html' -o -name '*.css' -o -name '*.ts' -o -name '*.js' -o -name '*.scss' \) -print | egrep -v ${exclude_pattern})) # NOTE There must be a space between the parens and its contents or it won't work.
-echo "Searching shell files..."
-files+=($(find . -type f \( -name '*.sh' -o -name '*.bash' -o -name '*.ksh' -o -name '*.csh' -o -name '*.tcsh' -o -name '*.fsh' \) -print | egrep -v ${exclude_pattern})) # NOTE There must be a space between the parens and its contents or it won't work.
-echo "Searching make files..."
-files+=($(find . -type f -name 'Makefile' -print | egrep -v ${exclude_pattern}))
-echo "Searching txt files..."
-files+=($(find . -type f -name '*.txt' -print | egrep -v ${exclude_pattern}))
-echo "Searching yaml|yml files..."
-files+=($(find . -type f \( -name '*.yaml' -o -name '*.yml' \) -print | egrep -v ${exclude_pattern})) # NOTE There must be a space between the parens and its contents or it won't work.
-files+=($(find . -type f -name '.gitignore' -print | egrep -v ${exclude_pattern}))
-echo "Searching SQL files..."
-files+=($(find . -type f -name '*.sql' -print | egrep -v ${exclude_pattern}))
+while IFS='' read -r line; do files+=("$line"); done < <(git ls-files -c "${filetypes[@]}" | grep -E -v "${exclude_pattern}")
 
 # This is the copyright line to look for - adjust as necessary
 copyright_line="Copyright The Linux Foundation"
@@ -42,24 +40,24 @@ missing_license_header=0
 # For each file...
 echo "Checking ${#files[@]} source code files for the license header..."
 for file in "${files[@]}"; do
-  # echo "Processing file ${file}..."
+	# echo "Processing file ${file}..."
 
-  # Header is typically one of the first few lines in the file...
-  head -4 "${file}" | grep -q "${copyright_line}"
-  # Find it? exit code value of 0 indicates the grep found a match
-  exit_code=$?
-  if [[ ${exit_code} -ne 0 ]]; then
-    echo "${file} is missing the license header"
-    # update our flag - we'll fail the test
-    missing_license_header=1
-  fi
+	# Header is typically one of the first few lines in the file...
+	head -4 "${file}" | grep -q "${copyright_line}"
+	# Find it? exit code value of 0 indicates the grep found a match
+	exit_code=$?
+	if [[ ${exit_code} -ne 0 ]]; then
+		echo "${file} is missing the license header"
+		# update our flag - we'll fail the test
+		missing_license_header=1
+	fi
 done
 
 # Summary
 if [[ ${missing_license_header} -eq 1 ]]; then
-  echo "One or more source files is missing the license header."
+	echo "One or more source files is missing the license header."
 else
-  echo "License check passed."
+	echo "License check passed."
 fi
 
 # Exit with status code 0 = success, 1 = failed

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/evalphobia/logrus_fluent"
 	"github.com/sirupsen/logrus"
@@ -113,7 +114,7 @@ func main() {
 	}
 
 	// Support GET/POST monitoring "ping".
-	http.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/ping", func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprintf(w, "OK\n")
 	})
 
@@ -156,7 +157,12 @@ func main() {
 	} else {
 		addr = *bind + ":" + *port
 	}
-	err := http.ListenAndServe(addr, mux)
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 3 * time.Second,
+	}
+	err := server.ListenAndServe()
 	if err != nil {
 		logrus.WithError(err).Fatal("http listener error")
 	}

--- a/responses.go
+++ b/responses.go
@@ -20,7 +20,6 @@ type casValidationResponse struct {
 type casServiceResponse struct {
 	// I'm not able to get xmlnas:cas to show up using native namespace in
 	// XMLName, so we're using a workaround of setting a XMLNS attribute.
-	//XMLName xml.Name `json:"-" xml:"http://www.yale.edu/tp/cas cas:serviceResponse"
 	XMLName xml.Name `json:"-" xml:"cas:serviceResponse"`
 	XMLNS   string   `json:"-" xml:"xmlns:cas,attr"`
 


### PR DESCRIPTION
- checkout action before setup-go action allows for module caching.
- ioutil is deprecated.
- Update labels for unused function params, constansts, and more.
- Copy in the latest version of our check-headers.sh script which uses `git ls-files` and better, explicit array-handling behavior.
- Add a ReadHeaderTimeout on our http.Server per best practice.