### PR TITLE
feat: embed error.html template and move loading to main

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,5 @@ USER nonroot
 EXPOSE 8080
 
 COPY --from=builder /go/bin/auth0-cas-server-go /auth0-cas-server-go
-COPY --from=builder /build/templates /templates
 
 ENTRYPOINT ["/auth0-cas-server-go", "-p=8080"]

--- a/main.go
+++ b/main.go
@@ -84,6 +84,9 @@ func main() {
 	logger := slog.New(handler)
 	slog.SetDefault(logger)
 
+	// Initialize error template after logging is set up.
+	initErrorTemplate()
+
 	// Instrument Open Telemetry.
 	if !*noTrace {
 		// Start OTLP forwarder and register the global tracing provider.

--- a/responses.go
+++ b/responses.go
@@ -7,6 +7,7 @@ package main
 // spell-checker:disable
 import (
 	"context"
+	_ "embed"
 	"encoding/json"
 	"encoding/xml"
 	"errors"
@@ -80,6 +81,8 @@ var (
 
 	// spell-checker:enable
 
+	//go:embed templates/error.html
+	errorTemplateContent string
 	// errorTemplate is the HTML template for error pages.
 	errorTemplate *template.Template
 )
@@ -91,10 +94,11 @@ type ErrorPageData struct {
 	ShowBackButton bool
 }
 
-// init initializes the error page template.
-func init() {
+// initErrorTemplate initializes the error page template from embedded content.
+// This should be called from main() after logging is set up.
+func initErrorTemplate() {
 	var err error
-	errorTemplate, err = template.ParseFiles("templates/error.html")
+	errorTemplate, err = template.New("error.html").Parse(errorTemplateContent)
 	if err != nil {
 		// Log error but don't fail - we'll fall back to plain text errors.
 		// This allows the service to start even if templates are missing.


### PR DESCRIPTION
- Bundle error.html template using go:embed for self-contained binaries
- Move template loading from init() to main() after logging setup
- Remove template file copy from Dockerfile since templates are embedded
- Add proper error template initialization with structured logging
- Support ko builds with no external file dependencies
- Remove template copy from Dockerfile

🤖 Generated with GitHub Copilot (via Zed)